### PR TITLE
RFC/WIP: Add ZlibBuilder as a dependency

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -7,7 +7,7 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/libxml2-*
-./autoconf.sh
+./autogen.sh
 ./configure --prefix=${prefix} --host=${target} --without-python --with-zlib=${prefix}/lib
 make -j${nproc} install
 """

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,7 +18,7 @@ products(prefix) = [
 platforms = supported_platforms()
 
 dependencies = [
-    "https://github.com/bicycle1885/ZlibBuilder/blob/v1.2.11-3/build_tarballs.jl"
+    "https://raw.githubusercontent.com/bicycle1885/ZlibBuilder/v1.2.11-3/build_tarballs.jl",
 ]
 
 autobuild(pwd(), "XML2Builder", platforms, sources, script, products, dependencies)

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,8 +1,8 @@
 using BinaryBuilder
 
 sources = [
-    "ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz" =>
-    "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c",
+    "https://github.com/GNOME/libxml2/archive/v2.9.7.tar.gz" =>
+        "a7b52278afca823d263deb8b4b33710735f1b5208a351173b2deb78a6d936412",
 ]
 
 script = raw"""

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,7 +18,7 @@ products(prefix) = [
 platforms = supported_platforms()
 
 dependencies = [
-    "https://raw.githubusercontent.com/bicycle1885/ZlibBuilder/v1.2.11-3/build_tarballs.jl",
+    "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.0/build.jl",
 ]
 
-autobuild(pwd(), "XML2Builder", platforms, sources, script, products, dependencies)
+build_tarballs(ARGS, "XML2Builder", sources, script, platforms, products, dependencies)

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,7 +18,7 @@ products(prefix) = [
 platforms = supported_platforms()
 
 dependencies = [
-    "https://github.com/staticfloat/ZlibBuilder/blob/v1.2.11-3/build_tarballs.jl"
+    "https://github.com/bicycle1885/ZlibBuilder/blob/v1.2.11-3/build_tarballs.jl"
 ]
 
 autobuild(pwd(), "XML2Builder", platforms, sources, script, products, dependencies)

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -7,6 +7,7 @@ sources = [
 
 script = raw"""
 cd ${WORKSPACE}/srcdir/libxml2-*
+./autoconf.sh
 ./configure --prefix=${prefix} --host=${target} --without-python --with-zlib=${prefix}/lib
 make -j${nproc} install
 """

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,52 +3,22 @@ using BinaryBuilder
 sources = [
     "ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz" =>
     "f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c",
-    "https://zlib.net/zlib-1.2.11.tar.gz" =>
-    "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
 ]
 
-products = prefix -> [
+script = raw"""
+cd ${WORKSPACE}/srcdir/libxml2-*
+./configure --prefix=${prefix} --host=${target} --without-python --with-zlib=${prefix}/lib
+make -j${nproc} install
+"""
+
+products(prefix) = [
     LibraryProduct(prefix, "libxml2", :libxml2)
 ]
 
+platforms = supported_platforms()
 
-# Linux and Unix
-# --------------
-
-platforms = [
-    BinaryProvider.Linux(:i686, :glibc),
-    BinaryProvider.Linux(:x86_64, :glibc),
-    BinaryProvider.Linux(:aarch64, :glibc),
-    BinaryProvider.Linux(:armv7l, :glibc),
-    BinaryProvider.Linux(:powerpc64le, :glibc),
-    BinaryProvider.MacOS(),
+dependencies = [
+    "https://github.com/staticfloat/ZlibBuilder/blob/v1.2.11-3/build_tarballs.jl"
 ]
-script = raw"""
-cd $WORKSPACE/srcdir
-cd zlib-1.2.11/
-./configure --prefix=/
-make install
-cd ../libxml2-2.9.7/
-./configure --prefix=/ --host=$target --without-python --with-zlib=$(pwd)/../../destdir
-make install
-"""
-autobuild(pwd(), "XML2Builder", platforms, sources, script, products)
 
-
-# Windows
-# -------
-
-platforms = [
-    BinaryProvider.Windows(:i686),
-    BinaryProvider.Windows(:x86_64),
-]
-script = raw"""
-cd $WORKSPACE/srcdir
-cd zlib-1.2.11/
-./configure --prefix=/
-make install LDSHAREDLIBC=''
-cd ../libxml2-2.9.7/
-./configure --prefix=/ --host=$target --without-python --with-zlib=$(pwd)/../../destdir
-make install
-"""
-autobuild(pwd(), "XML2Builder", platforms, sources, script, products)
+autobuild(pwd(), "XML2Builder", platforms, sources, script, products, dependencies)


### PR DESCRIPTION
This makes building zlib as part of the build here unnecessary. Also, build for all platforms supported by BinaryBuilder, thereby fixing #4.

cc also @staticfloat for a review